### PR TITLE
CERT-1067 Upload gambit binary to releases with CI

### DIFF
--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -18,3 +18,24 @@ jobs:
           key: ${{ runner.os }}-cargo-bin
       - name: Build and Test
         run: make
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./target/release/gambit
+          asset_name: gambit
+          # asset_content_type: application/zip
+        

--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -18,45 +18,28 @@ jobs:
           key: ${{ runner.os }}-cargo-bin
       - name: Build and Test
         run: make
-
-        # upload artifact to action
-      - uses: actions/upload-artifact@v3
-        if: startsWith(github.event.ref, 'refs/tags/v') # upload the artifact only when we create a new version tag
+      - name: Rename gambit binary
+        run: mv ./target/release/gambit ./target/release/gambit-${{ github.ref_name }}
+        if: startsWith(github.event.ref, 'refs/tags/v') # only on new tag creation
+      - name: Upload artifact to action
+        uses: actions/upload-artifact@v3
+        if: startsWith(github.event.ref, 'refs/tags/v') # only on new tag creation
         with:
           name: gambit-${{ github.ref_name }}
-          path: ./target/release/gambit
+          path: ./target/release/gambit-${{ github.ref_name }}
 
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.event.ref, 'refs/tags/v') # create a release only when we create a new version tag
+    if: startsWith(github.event.ref, 'refs/tags/v') #  only on new tag creation
     steps:
-
-        # create a new release in the repository
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-
-        # download the artifact
-      - uses: actions/download-artifact@v3
+      - name: Download artifact
+        uses: actions/download-artifact@v3
         with:
           name: gambit-${{ github.ref_name }}
-
-        # re-upload the artifact to the new release
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        uses: ncipollo/release-action@v1
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: gambit-${{ github.ref_name }}
-          asset_name: gambit-${{ github.ref_name }}
-          asset_content_type: application/rust
+          artifacts: "gambit-${{ github.ref_name }}"
+          allowUpdates: true
+          name: Release ${{ github.ref_name }}

--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Cache cargo bin
@@ -19,27 +21,33 @@ jobs:
       - name: Build and Test
         run: make
       - name: Rename gambit binary
-        run: mv ./target/release/gambit ./target/release/gambit-${{ github.ref_name }}
+        run: mv ./target/release/gambit ./target/release/gambit-$TAG
         if: startsWith(github.event.ref, 'refs/tags/v') # only on new tag creation
       - name: Upload artifact to action
         uses: actions/upload-artifact@v3
         if: startsWith(github.event.ref, 'refs/tags/v') # only on new tag creation
         with:
-          name: gambit-${{ github.ref_name }}
-          path: ./target/release/gambit-${{ github.ref_name }}
+          name: gambit-${{ env.TAG }}
+          path: ./target/release/gambit-${{ env.TAG }}
 
   release:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.event.ref, 'refs/tags/v') #  only on new tag creation
+    env:
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: gambit-${{ github.ref_name }}
-      - name: Create release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "gambit-${{ github.ref_name }}"
-          allowUpdates: true
-          name: Release ${{ github.ref_name }}
+          name: gambit-${{ env.TAG }}
+      - name: Create a release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_exist=$(gh release view $TAG 2>&1 || exit 0)
+          if [ "$release_exist" = "release not found" ]; then
+            gh release create $TAG gambit-$TAG --title "Release $TAG" --generate-notes --latest
+          else
+            gh release upload $TAG gambit-$TAG
+          fi

--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -37,6 +37,7 @@ jobs:
     env:
       TAG: ${{ github.ref_name }}
     steps:
+      - uses: actions/checkout@v3
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -18,16 +18,38 @@ jobs:
           key: ${{ runner.os }}-cargo-bin
       - name: Build and Test
         run: make
+
+        # upload artifact to action
+      - uses: actions/upload-artifact@v3
+        if: startsWith(github.event.ref, 'refs/tags/v') # upload the artifact only when we create a new version tag
+        with:
+          name: gambit-${{ github.ref_name }}
+          path: ./target/release/gambit
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.event.ref, 'refs/tags/v') # create a release only when we create a new version tag
+    steps:
+
+        # create a new release in the repository
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
+
+        # download the artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: gambit-${{ github.ref_name }}
+
+        # re-upload the artifact to the new release
       - name: Upload Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1
@@ -35,7 +57,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./target/release/gambit
-          asset_name: gambit
+          asset_path: gambit-${{ github.ref_name }}
+          asset_name: gambit-${{ github.ref_name }}
           asset_content_type: application/rust
-        

--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -37,5 +37,5 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./target/release/gambit
           asset_name: gambit
-          # asset_content_type: application/zip
+          asset_content_type: application/rust
         


### PR DESCRIPTION
### Use cases

- Pushing a commit without a tag: will not upload gambit binary or create a release.
- Creating a new tag: will create a new release with the binary and the tag.
- Creating a new release with a new tag: will upload the binary to the release without making other changes to the release.

### More details
- The binary is uploaded to the action and to the release.
- Any creation of a tag would trigger the CI.