### PR TITLE
Move println statement out of lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,10 +183,6 @@ pub fn run_mutate(
     }
 
     let t = start.elapsed().as_secs_f64();
-    // println!(
-    //     "Generated {} mutants in {:.2} seconds",
-    //     total_num_mutants, t
-    // );
     log::info!("Generated {} mutants in {}", total_num_mutants, t);
     Ok(results)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,10 +183,10 @@ pub fn run_mutate(
     }
 
     let t = start.elapsed().as_secs_f64();
-    println!(
-        "Generated {} mutants in {:.2} seconds",
-        total_num_mutants, t
-    );
+    // println!(
+    //     "Generated {} mutants in {:.2} seconds",
+    //     total_num_mutants, t
+    // );
     log::info!("Generated {} mutants in {}", total_num_mutants, t);
     Ok(results)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,8 +485,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn execute_mutation(params: Vec<MutateParams>) -> Result<(), Box<dyn std::error::Error>> {
     let start = std::time::Instant::now();
     let result = run_mutate(params)?;
-    let total_num_mutants = result.values().flat_map(|x|x).count();
     let t = start.elapsed().as_secs_f64();
+    let total_num_mutants = result.values().flat_map(|x|x).count();
     println!(
         "Generated {} mutants in {:.2} seconds",
         total_num_mutants, t

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     params.solc_base_path = basepath;
                     params.solc_remappings = remapping;
                 }
-                run_mutate(mutate_params)?;
+                execute_mutation(mutate_params)?;
             } else {
                 log::debug!("Running CLI MutateParams: {:#?}", &params);
                 // # Path Resolution for CLI Provided Parameters
@@ -469,8 +469,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 params.solc_include_path = solc_include_path;
                 params.solc_base_path = solc_basepath;
                 params.solc_remappings = solc_remapping;
-
-                run_mutate(vec![*params])?;
+                
+                execute_mutation(vec![*params])?;
             }
         }
         Command::Summary(params) => {
@@ -480,6 +480,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+
+/// Execute mutation
+fn execute_mutation(params: Vec<MutateParams>) -> Result<(), Box<dyn std::error::Error>> {
+    let start = std::time::Instant::now();
+    let result = run_mutate(params)?;
+    let total_num_mutants = result.values().flat_map(|x|x).count();
+    let t = start.elapsed().as_secs_f64();
+    println!(
+        "Generated {} mutants in {:.2} seconds",
+        total_num_mutants, t
+    );
+
+    Ok(())
+}
 /// Resolve a filename with respect to the directory containing the config file
 fn resolve_config_file_path(
     path: &String,


### PR DESCRIPTION
This PR moves the println! statement from lib.rs to main.rs. This is necessary because when using Gambit as a library the println! statement output could overwrite/append a print with return carriage.

The println! isn't necessary in the lib.rs and hence moved to main.rs