### PR TITLE
Change ci triggers

### DIFF
--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -1,7 +1,16 @@
 name: Gambit
 
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - main
+    tags: 
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+  
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full

--- a/.github/workflows/gambit.yml
+++ b/.github/workflows/gambit.yml
@@ -3,14 +3,14 @@ name: Gambit
 on:
   push:
     branches:
-      - main
+      - master
     tags: 
       - 'v*'
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
-  
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full


### PR DESCRIPTION
The ci will run on the following events:

- PR on the `master` branch
- Push to the `master` branch
- Create a new tag
- Manually triggering the workflow from github actions ui

It will not run when:

-  pushing changes to a side branch
- won't run twice when pushing changes to a branch with a pr